### PR TITLE
Fixed from_str and changed 'deriving' to 'derive'

### DIFF
--- a/src/abs.rs
+++ b/src/abs.rs
@@ -1,14 +1,14 @@
 
-#[deriving(Show, Clone)]
+#[derive(Show, Clone)]
 pub struct Type(pub String);
 
-#[deriving(Show, Clone)]
+#[derive(Show, Clone)]
 pub enum Stm {
     Vardef(Expr, Type),
     Assign(Expr, Expr),
 }
 
-#[deriving(Show, Clone)]
+#[derive(Show, Clone)]
 pub enum Expr {
     Id(String),
     LitInt(int),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -6,7 +6,7 @@ use abs::Expr::{Id, LitInt, Neg, Plus, Minus};
 use abs::Stm;
 use abs::Stm::{Vardef, Assign};
 
-#[deriving(Show)]
+#[derive(Show)]
 struct Env(HashMap<String, int>);
 
 impl Env {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,8 +6,9 @@ use abs::Expr::{Id, LitInt, Neg, Plus, Minus};
 use abs::Stm;
 use abs::Stm::{Vardef, Assign};
 use abs::Type;
+use std::str::FromStr;
 
-#[deriving(Show)]
+#[derive(Show)]
 pub struct Line<'a>(pub &'a str);
 
 struct ParseRule {
@@ -81,7 +82,7 @@ impl Parser {
 
     fn vardef(&self, cap: Captures) -> Stm {
         let e = self.parse_expr(cap.at(1).unwrap());
-        let t = cap.at(2).and_then(from_str).unwrap();
+        let t = cap.at(2).and_then(FromStr::from_str).unwrap();
         return Vardef(e, Type(t));
     }
 
@@ -110,12 +111,12 @@ impl Parser {
     }
 
     fn id(&self, cap: Captures) -> Expr {
-        let s = cap.at(1).and_then(from_str).unwrap();
+        let s = cap.at(1).and_then(FromStr::from_str).unwrap();
         return Id(s);
     }
 
     fn litint(&self, cap: Captures) -> Expr {
-        let i = cap.at(1).and_then(from_str).unwrap();
+        let i = cap.at(1).and_then(FromStr::from_str).unwrap();
         return LitInt(i);
     }
 


### PR DESCRIPTION
So apparently in the latest nightly build of the Rust compiler, they removed the from_str method from the standard prelude. Because of this there are several options to fix it. I chose to ```use std::str::FromStr;``` and call ```FromStr::from_str```.

Credit for pointing this out goes to [/u/dbappup](http://www.reddit.com/user/dbaupp) on reddit: http://www.reddit.com/r/rust/comments/2r8o8o/diy_make_your_own_programming_language_in_rust/cndoqf6

Also, I changed the "deriving" to "derive" because the latest nightly flags those as deprecated in favor of "derive."

I too am a Rust newbie and do appreciate your blog post about your Ion language. It's cool to see how everything works.